### PR TITLE
[PD-11640] Make node GPU resource names configurable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,102 @@
+pipeline {
+
+  agent {
+    kubernetes {
+      yamlFile 'ci/kubernetes-pod.yaml'
+    }
+  }
+
+  parameters {
+
+    string(
+      name: 'CONTAINER_REGISTRY',
+      defaultValue: '598971202176.dkr.ecr.us-west-2.amazonaws.com',
+      description: 'The container image registry to push images to'
+    )
+
+    string(
+      name: 'IMAGE_TAG',
+      defaultValue: '1.21.0-pd.0',
+      description: 'The tag to use for building the container image'
+    )
+
+    string(
+      name: 'BASEIMAGE',
+      defaultValue: '598971202176.dkr.ecr.us-west-2.amazonaws.com/3rdparty/ubuntu:20.10',
+      description: 'The tag to use for building the container image'
+    )
+
+}
+
+environment {
+
+  CONTAINER_REGISTRY="${params.CONTAINER_REGISTRY}"
+  IMAGE_TAG="${params.IMAGE_TAG}"
+  BASEIMAGE="${params.BASEIMAGE}"
+
+}
+
+  stages {
+
+    stage('Setup') {
+      steps {
+        container('golang') {
+          sh '''
+            apt-get update
+            apt-get install -y podman pip
+            pip3 install awscli==1.19.76
+            aws ecr get-login-password --region us-west-2 \
+              | podman login --username AWS --password-stdin $CONTAINER_REGISTRY
+          '''
+        }
+      }
+    }
+
+    stage('Build binary') {
+      steps {
+        container('golang') {
+          dir('./cluster-autoscaler') {
+            sh 'go build -o ./build/cluster-autoscaler-$(go env GOARCH)'
+          }
+        }
+      }
+    }
+
+    stage('Run tests') {
+      steps {
+        container('golang') {
+          dir('./cluster-autoscaler') {
+            sh 'go test ./...'
+          }
+        }
+      }
+    }
+
+    stage('Build container image') {
+      steps {
+        container('golang') {
+          dir('./cluster-autoscaler') {
+            sh '''
+              podman build \
+                -f Dockerfile.amd64 \
+                --build-arg=BASEIMAGE=$BASEIMAGE \
+                -t $CONTAINER_REGISTRY/3rdparty/cluster-autoscaler:$IMAGE_TAG \
+                ./build
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Push container image') {
+      //when { branch 'master' }
+      steps {
+        container('golang') {
+          sh 'podman push $CONTAINER_REGISTRY/3rdparty/cluster-autoscaler:$IMAGE_TAG'
+        }
+      }
+    }
+
+  }
+}
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ environment {
     }
 
     stage('Push container image') {
-      //when { branch 'master' }
+      when { branch 'cluster-autoscaler-release-1.21' }
       steps {
         container('golang') {
           sh 'podman push $CONTAINER_REGISTRY/3rdparty/cluster-autoscaler:$IMAGE_TAG'

--- a/ci/kubernetes-pod.yaml
+++ b/ci/kubernetes-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: cluster-autoscaler_build
+  annotations:
+    iam.amazonaws.com/role: jenkins-k8s-agent
+spec:
+  containers:
+  - name: golang
+    image: 598971202176.dkr.ecr.us-west-2.amazonaws.com/tools/golang:1.17.1
+    command:
+    - cat
+    tty: true
+    securityContext:
+      privileged: true
+

--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -1,3 +1,4 @@
+build/
 cluster-autoscaler
 cluster-autoscaler-amd64
 cluster-autoscaler-arm64

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -65,6 +65,8 @@ type AutoscalingOptions struct {
 	MinMemoryTotal int64
 	// GpuTotal is a list of strings with configuration of min/max limits for different GPUs.
 	GpuTotal []GpuLimits
+	// GpuResourceNames is a list of GPU resource names the node may have.
+	GpuResourceNames []string
 	// NodeGroupAutoDiscovery represents one or more definition(s) of node group auto-discovery
 	NodeGroupAutoDiscovery []string
 	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -125,6 +125,7 @@ var (
 	coresTotal               = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
 	memoryTotal              = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
 	gpuTotal                 = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
+	gpuResourceNames         = flag.String("gpu-resource-names", "", "Comma separated list of GPU resource names the node may have.")
 	cloudProviderFlag        = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider,
 		"Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders, ",")+"]")
 	maxBulkSoftTaintCount      = flag.Int("max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
@@ -198,6 +199,9 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 	if err != nil {
 		klog.Fatalf("Failed to parse flags: %v", err)
 	}
+
+	parsedGpuResourceNames := strings.Split(strings.ReplaceAll(*gpuResourceNames, " ", ""), ",")
+
 	return config.AutoscalingOptions{
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
 			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
@@ -226,6 +230,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxMemoryTotal:                     maxMemoryTotal,
 		MinMemoryTotal:                     minMemoryTotal,
 		GpuTotal:                           parsedGpuTotal,
+		GpuResourceNames:                   parsedGpuResourceNames,
 		NodeGroups:                         *nodeGroupsFlag,
 		ScaleDownDelayAfterAdd:             *scaleDownDelayAfterAdd,
 		ScaleDownDelayAfterDelete:          *scaleDownDelayAfterDelete,


### PR DESCRIPTION
Adds a `--gpu-resource-names` flag to specify the GPU resource names wait for in a node. Eg:
```
--gpu-resource-names=nvidia.com/gpu,microsoft.com/directx
```

The node is considered ready if any one of the given resource names is found as allocatable on the node.